### PR TITLE
Update meta tag description

### DIFF
--- a/frontend/_data/index.html.yml
+++ b/frontend/_data/index.html.yml
@@ -2,7 +2,8 @@
   site:
     title: "Knight Hacks"
     description: "Giving people a space to learn and do things they’ve never done before"
-    contact: "contact@knighthacks.org"
+    metaDescription: "The official website of the Knight Hacks hackathon, happening January 15th at UCF."
+    contact: "team@knighthacks.org"
     socialLinks:
       facebook: "//www.facebook.com/knighthacks"
       twitter: "//twitter.com/knighthacks"

--- a/frontend/_src/index.html
+++ b/frontend/_src/index.html
@@ -5,7 +5,7 @@
     <title>{{ site.title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <meta name="description" content="{{ site.description }}">
+    <meta name="description" content="{{ site.metaDescription }}">
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-touch-fullscreen" content="yes">


### PR DESCRIPTION
Interestingly enough, we already had a meta description, but since text
on the page contained Knight Hacks, Google preferred that snippet over
the description for the search term Knight Hacks. This will hopefully
steer Google in the right direction.

Updates #42